### PR TITLE
fix json tags in process struct types

### DIFF
--- a/process.go
+++ b/process.go
@@ -33,20 +33,20 @@ type ProcessAction struct {
 
 // ProcessAssignee represents a ProcessState assignee
 type ProcessAssignee struct {
-	Type     string           `json:type`
-	Entities []*ProcessEntity `json:entities`
+	Type     string           `json:"type"`
+	Entities []*ProcessEntity `json:"entities"`
 }
 
 // ProcessEntity represents a process assignee entity
 type ProcessEntity struct {
-	Entity      *Entity `json:entity`
-	IncludeSubs bool    `json:includeSubs`
+	Entity      *Entity `json:"entity"`
+	IncludeSubs bool    `json:"includeSubs"`
 }
 
 // Entity is the concrete representation of a process entity
 type Entity struct {
-	Type string `json:type`
-	Code string `json:code`
+	Type string `json:"type"`
+	Code string `json:"code"`
 }
 
 func DecodeProcess(b []byte) (p *Process, err error) {


### PR DESCRIPTION
This PR fixes struct tags for process struct types. These lines fails to specify the json tags due to the absent of quotes. Decoding succeeds because of the default unmarshaler of encoding/json.