### PR TITLE
fix initialization of structs in documents

### DIFF
--- a/app.go
+++ b/app.go
@@ -89,7 +89,7 @@ func (f UpdateKey) MarshalJSON() ([]byte, error) {
 //
 //	func handler(w http.ResponseWriter, r *http.Request) {
 //		c := appengine.NewContext(r)
-//		app := &kintone.App{urlfetch.Client(c)}
+//		app := &kintone.App{Client: urlfetch.Client(c)}
 //		...
 //	}
 //
@@ -104,7 +104,7 @@ func (f UpdateKey) MarshalJSON() ([]byte, error) {
 //	func main() {
 //		proxyURL, _ := url.Parse("https://proxy.example.com")
 //		transport := &http.Transport{Proxy: http.ProxyURL(proxyURL)}
-//		client := &http.Client(Transport: transport)
+//		client := &http.Client{Transport: transport}
 //		app := &kintone.App{Client: client}
 //		...
 //	}

--- a/doc.go
+++ b/doc.go
@@ -10,10 +10,10 @@ See https://developer.kintone.io for API specs.
 	)
 	...
 	app := &kintone.App{
-		"example.cybozu.com",
-		"user1",
-		"password",
-		25,
+		Domain:   "example.cybozu.com",
+		User:     "user1",
+		Password: "password",
+		AppId:    25,
 	}
 
 To retrieve 3 records from a kintone app (id=25):


### PR DESCRIPTION
This PR fixes godoc. Since `kintone.App` have number of fields, specifying only domain/user/password/appid yields `too few values in kintone.App{...}` error. Also fixes mistake in initialization of `*http.Client`.