### PR TITLE
update library document to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ To import this package:
 
     import "github.com/kintone/go-kintone"
 
-Visit the docs on [godoc.org][godoc].
+Visit the docs on [pkg.go.dev][pkggodev].
 
 [kintone]: https://www.kintone.com/
 [APIen]: https://developer.kintone.io/hc/en-us
 [APIja]: https://developer.cybozu.io/hc/ja
 [bsd2]: http://opensource.org/licenses/BSD-2-Clause
-[godoc]: http://godoc.org/github.com/kintone/go-kintone
+[pkggodev]: https://pkg.go.dev/github.com/kintone/go-kintone
 
 ## Copyright
 


### PR DESCRIPTION
The link to godoc.org already redirects to the new Go document platform, https://pkg.go.dev.