### PR TITLE
support Go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ To import this package:
 
     import "github.com/kintone/go-kintone"
 
-Visit the docs on [godoc.org][godoc].
+Visit the docs on [pkg.go.dev][pkggodev].
 
 [kintone]: https://www.kintone.com/
 [APIen]: https://developer.kintone.io/hc/en-us
 [APIja]: https://developer.cybozu.io/hc/ja
 [bsd2]: http://opensource.org/licenses/BSD-2-Clause
-[godoc]: http://godoc.org/github.com/kintone/go-kintone
+[pkggodev]: https://pkg.go.dev/github.com/kintone/go-kintone
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This software is licensed under [the BSD 2-clause license][bsd2].
 
 To import this package:
 
-    import "github.com/kintone/go-kintone"
+    import "github.com/kintone-labs/go-kintone"
 
 Visit the docs on [pkg.go.dev][pkggodev].
 
@@ -37,7 +37,7 @@ Visit the docs on [pkg.go.dev][pkggodev].
 [APIen]: https://developer.kintone.io/hc/en-us
 [APIja]: https://developer.cybozu.io/hc/ja
 [bsd2]: http://opensource.org/licenses/BSD-2-Clause
-[pkggodev]: https://pkg.go.dev/github.com/kintone/go-kintone
+[pkggodev]: https://pkg.go.dev/github.com/kintone-labs/go-kintone
 
 ## Copyright
 

--- a/app.go
+++ b/app.go
@@ -84,7 +84,7 @@ func (f UpdateKey) MarshalJSON() ([]byte, error) {
 //	import (
 //		"appengine"
 //		"appengine/urlfetch"
-//		"github.com/kintone/go-kintone"
+//		"github.com/kintone-labs/go-kintone"
 //		"net/http"
 //	)
 //
@@ -99,7 +99,7 @@ func (f UpdateKey) MarshalJSON() ([]byte, error) {
 //	import (
 //		"net/http"
 //		"net/url"
-//		"github.com/kintone/go-kintone"
+//		"github.com/kintone-labs/go-kintone"
 //	)
 //
 //	func main() {

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ See https://developer.kintone.io for API specs.
 	import (
 		"log"
 
-		"github.com/kintone/go-kintone"
+		"github.com/kintone-labs/go-kintone"
 	)
 	...
 	app := &kintone.App{

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kintone/go-kintone
+
+go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/kintone/go-kintone
+module github.com/kintone-labs/go-kintone
 
 go 1.17


### PR DESCRIPTION
This PR adds go.mod file to support Go modules. Since Go 1.18 is released, 1.17 is the minimum supported version right now.