### PR TITLE
Add GetRecordsWithTotalCount method to App

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -32,7 +32,7 @@ func DecodeGetRecordsCursorResponse(b []byte) (rc *GetRecordsCursorResponse, err
 	if err != nil {
 		return nil, err
 	}
-	listRecord, err := DecodeRecords(b)
+	listRecord, _, err := DecodeRecords(b)
 	if err != nil {
 		return nil, err
 	}

--- a/record.go
+++ b/record.go
@@ -322,24 +322,25 @@ func decodeRecordData(data recordData) (*Record, error) {
 }
 
 // DecodeRecords decodes JSON response for multi-get API.
-func DecodeRecords(b []byte) ([]*Record, error) {
+func DecodeRecords(b []byte) ([]*Record, string, error) {
 	var t struct {
-		Records []recordData `json:"records"`
+		Records    []recordData `json:"records"`
+		TotalCount string       `json:"total_count"`
 	}
 	err := json.Unmarshal(b, &t)
 	if err != nil {
-		return nil, errors.New("Invalid JSON format")
+		return nil, "", errors.New("Invalid JSON format")
 	}
 
 	rec_list := make([]*Record, len(t.Records))
 	for i, rd := range t.Records {
 		r, err := decodeRecordData(rd)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		rec_list[i] = r
 	}
-	return rec_list, nil
+	return rec_list, t.TotalCount, nil
 }
 
 // DecodeRecord decodes JSON response for single-get API.

--- a/record_test.go
+++ b/record_test.go
@@ -371,7 +371,7 @@ func TestDecodeRecords(t *testing.T) {
         }
     ]
 }`)
-	rec, err := DecodeRecords(j)
+	rec, _, err := DecodeRecords(j)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
According to the [API doc](https://developer.cybozu.io/hc/ja/articles/202331474#step2), getRecordsAPI(`k/v1/records.json`) can include `totalCount` in the response when `totalCount: true` is included in the request parameter.
Since we want get the totalCount when getting the records method in this SDK, I added `GetRecordsWithTotalCount` method to the App.
The interface of `GetRecords` is left as it is for the back compatibility.

If I need more action to get merge this. Please let me know.