### PR TITLE
Fix several lint errors

### DIFF
--- a/app.go
+++ b/app.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -314,7 +313,7 @@ func isJSON(contentType string) bool {
 }
 
 func parseResponse(resp *http.Response) ([]byte, error) {
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 
 	if err != nil {
@@ -542,7 +541,7 @@ func (app *App) Download(fileKey string) (*FileData, error) {
 			}
 		}
 		var ae AppError
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		json.Unmarshal(body, &ae)
 		ae.HttpStatus = resp.Status
@@ -573,7 +572,7 @@ func escapeQuotes(s string) string {
 //
 // If successfully uploaded, the key string of the uploaded file is returned.
 func (app *App) Upload(fileName, contentType string, data io.Reader) (key string, err error) {
-	f, err := ioutil.TempFile("", "go-kintone-")
+	f, err := os.CreateTemp("", "go-kintone-")
 	if err != nil {
 		return
 	}
@@ -1212,7 +1211,6 @@ func updateIndexToField(fieldCode [][]byte, fieldInfo map[string]*FieldInfo) {
 					sortedFieldCode.Fields[k].Index = i
 					i += 1
 				}
-
 			}
 		}
 	}

--- a/app.go
+++ b/app.go
@@ -587,6 +587,9 @@ func (app *App) Upload(fileName, contentType string, data io.Reader) (key string
 			escapeQuotes(fileName)))
 	h.Set("Content-Type", contentType)
 	fw, err := w.CreatePart(h)
+	if err != nil {
+		return
+	}
 	if _, err = io.Copy(fw, data); err != nil {
 		return
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -182,7 +182,7 @@ func handleResponseGetRecords(response http.ResponseWriter, request *http.Reques
 			return
 		}
 		var bodyRequest RequestBody
-		if err := json.Unmarshal([]byte(body), &bodyRequest); err != nil {
+		if err := json.Unmarshal(body, &bodyRequest); err != nil {
 			http.Error(response, "Body incorrect", http.StatusBadRequest)
 		}
 

--- a/app_test.go
+++ b/app_test.go
@@ -107,7 +107,7 @@ func handleResponseProcess(response http.ResponseWriter, request *http.Request) 
 
 func handleResponseForm(response http.ResponseWriter, request *http.Request) {
 	checkAuth(response, request)
-	if request.Method == "GET" {
+	if request.Method == http.MethodGet {
 		checkContentType(response, request)
 		testData := GetDataTestForm()
 		fmt.Fprint(response, testData.output)
@@ -116,14 +116,14 @@ func handleResponseForm(response http.ResponseWriter, request *http.Request) {
 
 func handleResponseRecordsCursor(response http.ResponseWriter, request *http.Request) {
 	checkAuth(response, request)
-	if request.Method == "GET" {
+	if request.Method == http.MethodGet {
 		testData := GetDataTestGetRecordsByCursor()
 		fmt.Fprint(response, testData.output)
-	} else if request.Method == "DELETE" {
+	} else if request.Method == http.MethodDelete {
 		checkContentType(response, request)
 		testData := GetTestDataDeleteCursor()
 		fmt.Fprint(response, testData.output)
-	} else if request.Method == "POST" {
+	} else if request.Method == http.MethodPost {
 		checkContentType(response, request)
 		testData := GetTestDataCreateCursor()
 		fmt.Fprint(response, testData.output)
@@ -133,10 +133,10 @@ func handleResponseRecordsCursor(response http.ResponseWriter, request *http.Req
 func handleResponseRecordComments(response http.ResponseWriter, request *http.Request) {
 	checkAuth(response, request)
 	checkContentType(response, request)
-	if request.Method == "POST" {
+	if request.Method == http.MethodPost {
 		testData := GetTestDataAddRecordComment()
 		fmt.Fprint(response, testData.output)
-	} else if request.Method == "DELETE" {
+	} else if request.Method == http.MethodDelete {
 		testData := GetDataTestDeleteRecordComment()
 		fmt.Fprint(response, testData.output)
 	}
@@ -144,7 +144,7 @@ func handleResponseRecordComments(response http.ResponseWriter, request *http.Re
 
 func handleResponseUploadFile(response http.ResponseWriter, request *http.Request) {
 	checkAuth(response, request)
-	if request.Method == "POST" {
+	if request.Method == http.MethodPost {
 		testData := GetDataTestUploadFile()
 		fmt.Fprint(response, testData.output)
 	}
@@ -153,13 +153,13 @@ func handleResponseUploadFile(response http.ResponseWriter, request *http.Reques
 func handleResponseGetRecord(response http.ResponseWriter, request *http.Request) {
 	checkAuth(response, request)
 	checkContentType(response, request)
-	if request.Method == "GET" {
+	if request.Method == http.MethodGet {
 		testData := GetTestDataGetRecord()
 		fmt.Fprint(response, testData.output)
-	} else if request.Method == "PUT" {
+	} else if request.Method == http.MethodPut {
 		testData := GetTestDataUpdateRecordByKey()
 		fmt.Fprint(response, testData.output)
-	} else if request.Method == "POST" {
+	} else if request.Method == http.MethodPost {
 		testData := GetTestDataAddRecord()
 		fmt.Fprint(response, testData.output)
 	}
@@ -168,7 +168,7 @@ func handleResponseGetRecord(response http.ResponseWriter, request *http.Request
 func handleResponseGetRecords(response http.ResponseWriter, request *http.Request) {
 	checkAuth(response, request)
 	checkContentType(response, request)
-	if request.Method == "GET" {
+	if request.Method == http.MethodGet {
 		type RequestBody struct {
 			App        uint64   `json:"app,string"`
 			Fields     []string `json:"fields"`
@@ -193,10 +193,10 @@ func handleResponseGetRecords(response http.ResponseWriter, request *http.Reques
 			testData := GetTestDataGetRecords()
 			fmt.Fprint(response, testData.output)
 		}
-	} else if request.Method == "DELETE" {
+	} else if request.Method == http.MethodDelete {
 		testData := GetTestDataDeleteRecords()
 		fmt.Fprint(response, testData.output)
-	} else if request.Method == "POST" {
+	} else if request.Method == http.MethodPost {
 		testData := GetTestDataAddRecords()
 		fmt.Fprint(response, testData.output)
 	}
@@ -505,14 +505,16 @@ func TestLookupFieldInFieldInfo(t *testing.T) {
 		t.Error("Fields failed", err)
 	}
 	for _, f := range fi {
-		if f.Lookup != nil {countLookup++}
+		if f.Lookup != nil {
+			countLookup++
+		}
 	}
 
 	if countLookup > 0 {
-		fmt.Printf("\nApp have %v Lookup field\n", countLookup);
+		fmt.Printf("\nApp have %v Lookup field\n", countLookup)
 	}
 
 	if countLookup == 0 {
-		fmt.Printf("\nApp have no Lookup field\n");
+		fmt.Printf("\nApp have no Lookup field\n")
 	}
 }

--- a/comment.go
+++ b/comment.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 )
 
-//
 const (
 	ConstCommentMentionTypeGroup      = "GROUP"
 	ConstCommentMentionTypeDepartment = "ORGANIZATION"

--- a/doc.go
+++ b/doc.go
@@ -17,6 +17,7 @@ See https://kintone.dev/en/ for API specs.
 	}
 
 To retrieve 3 records from a kintone app (id=25):
+
 	records, err := app.GetRecords(nil, "limit 3")
 	if err != nil {
 		log.Fatal(err)
@@ -24,6 +25,7 @@ To retrieve 3 records from a kintone app (id=25):
 	// use records
 
 To retrieve 10 latest comments in record (id=3) from a kintone app (id=25)
+
 	var offset uint64 = 0
 	var limit uint64 = 10
 	comments, err := app.GetRecordComments(3, "desc", offset, limit)
@@ -33,6 +35,7 @@ To retrieve 10 latest comments in record (id=3) from a kintone app (id=25)
 	// use comments
 
 To retrieve oldest 10 comments and skips the first 30 comments in record (id=3) from a kintone app (id=25)
+
 	var offset uint64 = 30
 	var limit uint64 = 10
 	comments, err := app.GetRecordComments(3, "asc", offset, limit)
@@ -42,6 +45,7 @@ To retrieve oldest 10 comments and skips the first 30 comments in record (id=3) 
 	// use comments
 
 To add comments into record (id=3) from a kintone app (id=25)
+
 	mentionMemberCybozu := &ObjMention{Code: "cybozu", Type: kintone.ConstCommentMentionTypeUser}
 	mentionGroupAdmin := &ObjMention{Code: "Administrators", Type: kintone.ConstCommentMentionTypeGroup}
 	mentionDepartmentAdmin := &ObjMention{Code: "Admin", Type: ConstCommentMentionTypeDepartment}
@@ -56,11 +60,11 @@ To add comments into record (id=3) from a kintone app (id=25)
 	// use comments id
 
 To remove comments (id=12) in the record (id=3) from a kintone app (id=25)
+
 	err := app.DeleteComment(3, 12)
 
 	if err != nil {
 		log.Fatal(err)
 	}
-
 */
 package kintone

--- a/field.go
+++ b/field.go
@@ -310,7 +310,7 @@ func (f DateTimeField) MarshalJSON() ([]byte, error) {
 
 // User represents a user entry.
 type User struct {
-	Code string `json:"code"` // A unique identifer of the user.
+	Code string `json:"code"` // A unique identifier of the user.
 	Name string `json:"name"` // The user name.
 }
 
@@ -330,7 +330,7 @@ func (f UserField) MarshalJSON() ([]byte, error) {
 
 // Organization represents a department entry.
 type Organization struct {
-	Code string `json:"code"` // A unique identifer of the department.
+	Code string `json:"code"` // A unique identifier of the department.
 	Name string `json:"name"` // The department name.
 }
 
@@ -350,7 +350,7 @@ func (f OrganizationField) MarshalJSON() ([]byte, error) {
 
 // Group represents a group(or role) entry.
 type Group struct {
-	Code string `json:"code"` // A unique identifer of the group(or role).
+	Code string `json:"code"` // A unique identifier of the group(or role).
 	Name string `json:"name"` // The group name.
 }
 

--- a/process.go
+++ b/process.go
@@ -23,7 +23,7 @@ type ProcessState struct {
 	Assignee *ProcessAssignee `json:"assignee"`
 }
 
-// ProcessAction representes a process management action
+// ProcessAction represents a process management action
 type ProcessAction struct {
 	Name       string `json:"name"`
 	From       string `json:"from"`

--- a/record.go
+++ b/record.go
@@ -289,7 +289,7 @@ func decodeRecordData(data recordData) (*Record, error) {
 				if err != nil {
 					return nil, err
 				}
-				r, err := decodeRecordData(recordData(rd))
+				r, err := decodeRecordData(rd)
 				if err != nil {
 					return nil, err
 				}

--- a/record.go
+++ b/record.go
@@ -42,7 +42,6 @@ func NewRecordWithId(id uint64, fields map[string]interface{}) *Record {
 // NewRecordWithIdAndRevision creates using an existing record id and revision.
 func NewRecordWithIdAndRevision(id uint64, revision int64, fields map[string]interface{}) *Record {
 	return &Record{id, revision, fields}
-
 }
 
 // MarshalJSON marshals field data of a record into JSON.

--- a/record_test.go
+++ b/record_test.go
@@ -434,14 +434,7 @@ func TestDecodeRecordsWithTotalCount(t *testing.T) {
 		"totalCount": "9999"
 	}`)
 
-	type Record struct {
-		id       uint64
-		revision int64
-		Fields   map[string]interface{}
-	}
-
 	rec, totalCount, err := DecodeRecordsWithTotalCount(b)
-
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This pull request fixes several general issues reported by golangci-lint. The following corrections are included:

- Use http.MethodGet or http.MethodPost instead of "GET" or "POST"
- Replace deprecated functions in io/ioutil
- Remove unused code
- Correct spelling errors